### PR TITLE
Downgrade to java 11 so that we can deploy on AWS

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
 	<name>api</name>
 	<description>arabic calligraphy api</description>
 	<properties>
-		<java.version>18</java.version>
+		<java.version>11</java.version>
 		<maven.build.timestamp.format>yyyy-MM-dd'T'HH-mm-ss'Z'</maven.build.timestamp.format>
 	</properties>
 	<dependencies>
@@ -46,8 +46,8 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
-                    <source>18</source>
-                    <target>18</target>
+                    <source>11</source>
+                    <target>11</target>
                 </configuration>
             </plugin>
         </plugins>

--- a/src/main/java/com/arabiccalligraphy/api/controller/HealthController.java
+++ b/src/main/java/com/arabiccalligraphy/api/controller/HealthController.java
@@ -1,0 +1,17 @@
+package com.arabiccalligraphy.api.controller;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Collections;
+import java.util.Map;
+
+@RestController
+public class HealthController {
+
+    @GetMapping("/")
+    public Map<String, String > health() {
+        return Collections.singletonMap("status", "ok");
+
+    }
+}

--- a/src/main/resources/application-prod.properties
+++ b/src/main/resources/application-prod.properties
@@ -1,0 +1,1 @@
+server.port=5000


### PR DESCRIPTION
Also, did the following things that are required to deploy the API on AWS:
1. add a health check controller that just prints out a status of OK when requesting `/`
2. add a properties file for production profile that specifies port 5000