### PR TITLE
add unit tests

### DIFF
--- a/src/main/java/com/arabiccalligraphy/api/model/Artist.java
+++ b/src/main/java/com/arabiccalligraphy/api/model/Artist.java
@@ -7,11 +7,13 @@ public class Artist {
     private String name;
     private List<Artwork> artworks;
 
-    public Artist(String name){
+    public Artist(String name) {
         this.name = name;
     }
 
-    public String getName() {return name;}
+    public String getName() {
+        return name;
+    }
 
     public void setName(String name) {
         this.name = name;

--- a/src/main/java/com/arabiccalligraphy/api/model/Artwork.java
+++ b/src/main/java/com/arabiccalligraphy/api/model/Artwork.java
@@ -1,7 +1,5 @@
 package com.arabiccalligraphy.api.model;
 
-import com.arabiccalligraphy.api.DAO.ArtworkDAO;
-
 import java.util.Arrays;
 
 public class Artwork {
@@ -14,7 +12,7 @@ public class Artwork {
     private int height;
     private String id;
 
-    public Artwork (String id, String title, String[] tags, String image, Artist artist, int width, int height){
+    public Artwork(String id, String title, String[] tags, String image, Artist artist, int width, int height) {
         this.title = title;
         this.tags = tags;
         this.image = image;
@@ -24,9 +22,13 @@ public class Artwork {
         this.id = id;
     }
 
-    public String getTitle() {return title;}
+    public String getTitle() {
+        return title;
+    }
 
-    public void setTitle(String title) {this.title = title;}
+    public void setTitle(String title) {
+        this.title = title;
+    }
 
     public String[] getTags() {
         return tags;
@@ -52,17 +54,29 @@ public class Artwork {
         this.artist = artist;
     }
 
-    public int getWidth() {return width;}
+    public int getWidth() {
+        return width;
+    }
 
-    public void setWidth(int width) {this.width = width;}
+    public void setWidth(int width) {
+        this.width = width;
+    }
 
-    public int getHeight() {return height;}
+    public int getHeight() {
+        return height;
+    }
 
-    public void setHeight(int height) {this.height = height;}
+    public void setHeight(int height) {
+        this.height = height;
+    }
 
-    public String getId() {return id;}
+    public String getId() {
+        return id;
+    }
 
-    public void setId(String id) {this.id = id;}
+    public void setId(String id) {
+        this.id = id;
+    }
 
     @Override
     public String toString() {

--- a/src/main/resources/application-test.properties
+++ b/src/main/resources/application-test.properties
@@ -1,0 +1,3 @@
+logging.level.com.arabiccalligraphy.api = INFO
+logging.level.org.springframework = OFF
+spring.main.banner-mode=off

--- a/src/test/java/com/arabiccalligraphy/api/ApiApplicationTests.java
+++ b/src/test/java/com/arabiccalligraphy/api/ApiApplicationTests.java
@@ -1,13 +1,31 @@
 package com.arabiccalligraphy.api;
 
+import com.arabiccalligraphy.api.controller.ArtworkController;
+import com.arabiccalligraphy.api.controller.HealthController;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 @SpringBootTest
+@ActiveProfiles("test")
 class ApiApplicationTests {
 
-	@Test
-	void contextLoads() {
-	}
+    @Autowired
+    private HealthController healthController;
+
+    @Autowired
+    private ArtworkController artworkController;
+
+    @Test
+    /*
+      This tests that both controllers are wired correctly and are started up when spring context starts
+     */
+    void contextLoads() {
+        assertThat(this.healthController).isNotNull();
+        assertThat(this.artworkController).isNotNull();
+    }
 
 }

--- a/src/test/java/com/arabiccalligraphy/api/controller/ArtworkControllerTests.java
+++ b/src/test/java/com/arabiccalligraphy/api/controller/ArtworkControllerTests.java
@@ -1,0 +1,67 @@
+package com.arabiccalligraphy.api.controller;
+
+import com.arabiccalligraphy.api.DAO.ArtworkDAO;
+import com.arabiccalligraphy.api.model.Artist;
+import com.arabiccalligraphy.api.model.Artwork;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+
+import java.util.*;
+
+import static org.hamcrest.Matchers.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(ArtworkController.class)
+@ActiveProfiles("test")
+public class ArtworkControllerTests {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private ArtworkDAO artworkDAO;
+
+    @BeforeEach
+    void setUp() {
+        Artist index = new Artist("index");
+        Artwork indexArt1 = new Artwork("1", "Index Artwork Title 1", new String[]{"tag1", "tag2"}, "img/index_art1.jpg", index, 100, 200);
+        Artwork indexArt2 = new Artwork("2", "Index Artwork Title 2", new String[]{"tag2", "tag4"}, "img/index_art2.jpg", index, 100, 200);
+        Artwork indexArt3 = new Artwork("3", "Index Artwork Title 3", new String[]{"tag4", "tag5"}, "img/index_art3.jpg", index, 100, 200);
+        List<Artwork> indexArtworks = new ArrayList<>(Arrays.asList(indexArt1, indexArt2, indexArt3));
+
+        Artist mokhtar = new Artist("mokhtar");
+        Artwork mokhtarArt1 = new Artwork("4", "Mokhtar Artwork Title 1", new String[]{"tag1", "tag3"}, "img/mokhtar_art1.jpg", mokhtar, 100, 200);
+        Artwork mokhtarArt2 = new Artwork("5", "Mokhtar Artwork Title 2", new String[]{"tag2", "tag3"}, "img/mokhtar_art2.jpg", mokhtar, 100, 200);
+        Artwork mokhtarArt3 = new Artwork("6", "Mokhtar Artwork Title 3", new String[]{"tag2", "tag5"}, "img/mokhtar_art3.jpg", mokhtar, 100, 200);
+        List<Artwork> mokhtarArtworks = new ArrayList<>(Arrays.asList(mokhtarArt1, mokhtarArt2, mokhtarArt3));
+
+        Map<String, List<Artwork>> mockedArtwork = new HashMap<>();
+        mockedArtwork.put("index.json", indexArtworks);
+        mockedArtwork.put("mokhtar.json", mokhtarArtworks);
+
+        Mockito.when(artworkDAO.getArtworks()).thenReturn(mockedArtwork);
+    }
+
+    @Test
+    void testGetArtworkForIndexAll() throws Exception {
+        mockMvc.perform(MockMvcRequestBuilders.get("/api/v1/artworks").contentType(MediaType.APPLICATION_JSON))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$", hasSize(3)))
+                .andExpect(jsonPath("$[0].id", is("1")))
+                .andExpect(jsonPath("$[1].id", is("2")))
+                .andExpect(jsonPath("$[2].id", is("3")))
+                .andExpect(content().string(containsString("Index Artwork Title")));
+    }
+
+    // todo: add more tests here
+}

--- a/src/test/java/com/arabiccalligraphy/api/controller/HealthControllerTest.java
+++ b/src/test/java/com/arabiccalligraphy/api/controller/HealthControllerTest.java
@@ -1,0 +1,32 @@
+package com.arabiccalligraphy.api.controller;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+
+import java.util.Map;
+
+import static org.hamcrest.Matchers.is;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(HealthController.class)
+@ActiveProfiles("test")
+public class HealthControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Test
+    void testHealthResponse() throws Exception {
+        mockMvc.perform(MockMvcRequestBuilders.get("/").contentType(MediaType.APPLICATION_JSON))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$", is(Map.of("status", "ok"))));
+    }
+}

--- a/src/test/resources/logback-test.xml
+++ b/src/test/resources/logback-test.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+    <include resource="org/springframework/boot/logging/logback/base.xml" />
+    <logger name="org.springframework" level="OFF"/>
+</configuration>


### PR DESCRIPTION
This is the beginning of unit tests for the controllers - I included the following:

1. `HealthControllerTest`: this ensures that doing a `GET /` returns a `{"status": "ok"}` response, which is important for Amazon AWS to know that the application is up and running and ready to accept requests.
2. `ArtworkControllerTests`: this is where we will add more tests to assert the correct functionality of the main API `/api/v1/artworks`.  I have created one example test, but we need more coverage to account for things like:

* pagination
* filtering
* filtering + pagination
* bad inputs (e.g., negative `pageSize`) 

Those tests should be added as part of issue #12 